### PR TITLE
feat: add support for huff input

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,7 +12,7 @@ repository = "https://github.com/kadenzipfel/bytepeep"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-strum = "0.24"
+strum = { version = "0.24", features = ["derive"] }
 strum_macros = "0.24"
 colored = "2.0.0"
 clap = { version = "4.0", features = ["derive"] }

--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ Contributions welcome!
 - [ ] Reassign jumps
 - [ ] Handle different inputs
   - [ ] Mnemonics
-  - [ ] Huff
+  - [x] Huff
 - [ ] Return tips along with optimized bytecode
 
 ### Disclaimer


### PR DESCRIPTION
## Description:

Partially closes #3 

**Usage**: `bytepeep ./Keccak.huff --source huff` 

_Default source type will be raw bytecode for backward compatibility._